### PR TITLE
Fix: change kernel-host to bind-host

### DIFF
--- a/changes/310.fix
+++ b/changes/310.fix
@@ -1,0 +1,1 @@
+Change a option 'kernel-host' to 'bind-host' of container

--- a/changes/310.fix
+++ b/changes/310.fix
@@ -1,1 +1,1 @@
-Change a option 'kernel-host' to 'bind-host' of container
+Fix a missing update for renaming `kernel-host` to `bind-host` in the initialization codes that auto-fills the value when not specified

--- a/changes/310.fix
+++ b/changes/310.fix
@@ -1,1 +1,1 @@
-Fix a missing update for renaming `kernel-host` to `bind-host` in the initialization codes that auto-fills the value when not specified
+Fix a missing update for renaming `kernel-host` to `bind-host` in the initialization codes that auto-fills the value when not specified and let it show an explicit warning if the legacy `kernel-host` key is configured

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -603,11 +603,13 @@ async def server_main(
             rpc_addr.port,
         )
     if 'kernel-host' in local_config['container']:
-        log.warning("The configuration parameter `container.kernel-host` is deprecated; use `container.bind-host` instead!")
+        log.warning("The configuration parameter `container.kernel-host` is deprecated; "
+                    "use `container.bind-host` instead!")
         # fallback for legacy configs
         local_config['container']['bind-host'] = local_config['container']['kernel-host']
     if not local_config['container']['bind-host']:
-        log.debug('auto-detecting `container.bind-host` from container subnet config and agent.rpc-listen-addr')
+        log.debug("auto-detecting `container.bind-host` from container subnet config "
+                  "and agent.rpc-listen-addr")
         local_config['container']['bind-host'] = await get_subnet_ip(
             etcd, 'container', fallback_addr=local_config['agent']['rpc-listen-addr'].host
         )

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -602,10 +602,14 @@ async def server_main(
             await identity.get_instance_ip(subnet_hint),
             rpc_addr.port,
         )
+    if 'kernel-host' in local_config['container']:
+        log.warning("The configuration parameter `container.kernel-host` is deprecated; use `container.bind-host` instead!")
+        # fallback for legacy configs
+        local_config['container']['bind-host'] = local_config['container']['kernel-host']
     if not local_config['container']['bind-host']:
-        log.debug('auto-detecting bind host')
+        log.debug('auto-detecting `container.bind-host` from container subnet config and agent.rpc-listen-addr')
         local_config['container']['bind-host'] = await get_subnet_ip(
-            etcd, 'container', local_config['agent']['rpc-listen-addr'].host
+            etcd, 'container', fallback_addr=local_config['agent']['rpc-listen-addr'].host
         )
     log.info('Agent external IP: {}', local_config['agent']['rpc-listen-addr'].host)
     log.info('Container external IP: {}', local_config['container']['bind-host'])

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -602,13 +602,13 @@ async def server_main(
             await identity.get_instance_ip(subnet_hint),
             rpc_addr.port,
         )
-    if not local_config['container']['kernel-host']:
-        log.debug('auto-detecting kernel host')
-        local_config['container']['kernel-host'] = await get_subnet_ip(
+    if not local_config['container']['bind-host']:
+        log.debug('auto-detecting bind host')
+        local_config['container']['bind-host'] = await get_subnet_ip(
             etcd, 'container', local_config['agent']['rpc-listen-addr'].host
         )
     log.info('Agent external IP: {}', local_config['agent']['rpc-listen-addr'].host)
-    log.info('Container external IP: {}', local_config['container']['kernel-host'])
+    log.info('Container external IP: {}', local_config['container']['bind-host'])
     if not local_config['agent']['region']:
         local_config['agent']['region'] = await identity.get_instance_region()
     log.info('Node ID: {0} (machine-type: {1}, host: {2})',
@@ -674,8 +674,8 @@ def main(
     config.override_with_env(raw_cfg, ('agent', 'pid-file'), 'BACKEND_PID_FILE')
     config.override_with_env(raw_cfg, ('container', 'port-range'),
                              'BACKEND_CONTAINER_PORT_RANGE')
-    config.override_with_env(raw_cfg, ('container', 'kernel-host'),
-                             'BACKEND_KERNEL_HOST_OVERRIDE')
+    config.override_with_env(raw_cfg, ('container', 'bind-host'),
+                             'BACKEND_BIND_HOST_OVERRIDE')
     config.override_with_env(raw_cfg, ('container', 'sandbox-type'), 'BACKEND_SANDBOX_TYPE')
     config.override_with_env(raw_cfg, ('container', 'scratch-root'), 'BACKEND_SCRATCH_ROOT')
     if debug:


### PR DESCRIPTION
After merging [#309](https://github.com/lablup/backend.ai-agent/pull/309) commit and executing `python -m ai.backend.agent.server --debug`, the key('kernel-host') error occurs. Following image shows the problem.

![image](https://user-images.githubusercontent.com/57058726/134113273-4a93dc02-9a6e-4619-87c6-be3df505ae39.png)

### To solve:
- fix `agent/server.py`. change *kernel-host* to *bind-host*.

### Discuss:
In fact, I was embarrassed that After merging and execute, the agent can't detect the kernel's status. It turns out that the agent.toml file was not modified after pull. If `the toml file` is modified, does the developer have to modify it on his own?